### PR TITLE
Fix SyntaxError caused by backslashes within f-string expressions

### DIFF
--- a/src/agentic_security/security_pipeline.py
+++ b/src/agentic_security/security_pipeline.py
@@ -1525,7 +1525,7 @@ tree = parse(xml_file, forbid_dtd=True, forbid_entities=True)
                 raise FileNotFoundError(f"Path not found: {path}")
 
             # Use sanitized path as cache key
-            cache_key = f"review_{path.replace('/', '_').replace('\\', '_')}"
+            cache_key = f"review_{path.replace('/', '_').replace('\\\\', '_')}"
             cached_results = None if skip_cache else self.cache.get_scan_results(cache_key)
 
             if cached_results and isinstance(cached_results, dict):


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/syndicate604/agentic-security/pull/1?shareId=99cc7ac2-5e53-4c09-805f-47e83ffda765).